### PR TITLE
Switch nonworking action types with working ones

### DIFF
--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -24,7 +24,7 @@ export function startMeeting(channelId) {
         }
 
         dispatch({
-            type: PostTypes.REMOVE_POST,
+            type: PostTypes.POST_REMOVED,
             data: creatingInProgressPost,
         });
 
@@ -53,13 +53,8 @@ function createTemporaryPost(channelId, userId, message, dispatch) {
     };
 
     dispatch({
-        type: PostTypes.RECEIVED_POSTS,
-        data: {
-            order: [],
-            posts: {
-                [post.id]: post,
-            },
-        },
+        type: PostTypes.RECEIVED_NEW_POST,
+        data: post,
         channelId,
     });
 


### PR DESCRIPTION
In version 5.14 of Mattermost, action types REMOVE_POST and RECEIVED_POSTS don't work. You can check it by trying to create a new meeting with the plugin. After clicking the button, there should be displayed a post like this for a few seconds:
![Screenshot_20190805_211926](https://user-images.githubusercontent.com/45372453/62498481-a7a96f80-b7df-11e9-9a89-e44ac1a83474.png)
But in version 5.14 it doesn't work.
Also, after the meeting is successfully created, this post should be removed, but it doesn't work either.

I switched these actions with POST_REMOVED and RECEIVED_NEW_POST and it works correctly now.