### PR TITLE
Update the plugin for Go 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/mattermost-plugin-skype4business
 
-go 1.12
+go 1.13
 
 require (
 	github.com/go-ldap/ldap v3.0.3+incompatible // indirect
@@ -24,5 +24,4 @@ require (
 	google.golang.org/grpc v1.22.0 // indirect
 )
 
-// Workaround for https://github.com/golang/go/issues/30831 and fallout.
-replace github.com/golang/lint => github.com/golang/lint v0.0.0-20190227174305-8f45f776aaf1
+replace willnorris.com/go/imageproxy => willnorris.com/go/imageproxy v0.8.1-0.20190422234945-d4246a08fdec

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,7 @@ github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
 github.com/golang/lint v0.0.0-20190227174305-8f45f776aaf1/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -452,3 +453,4 @@ honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 willnorris.com/go/gifresize v1.0.0/go.mod h1:eBM8gogBGCcaH603vxSpnfjwXIpq6nmnj/jauBDKtAk=
 willnorris.com/go/imageproxy v0.8.1-0.20190326225038-d4246a08fdec/go.mod h1:CKIesng3W4D4npJaypowqkxF33s3AH7EuohbR1miBGw=
+willnorris.com/go/imageproxy v0.8.1-0.20190422234945-d4246a08fdec/go.mod h1:CKIesng3W4D4npJaypowqkxF33s3AH7EuohbR1miBGw=


### PR DESCRIPTION
This commit makes it able to build the plugin with Go 1.13. 

Now, when you try to build it with Go 1.13, you see this error:
```
go: github.com/mattermost/mattermost-server@v5.12.0+incompatible requires
	willnorris.com/go/imageproxy@v0.8.1-0.20190326225038-d4246a08fdec: invalid pseudo-version: does not match version-control timestamp (2019-04-22T23:49:45Z)
./build/bin/manifest apply
mkdir -p server/dist;
cd server && env GOOS=linux GOARCH=amd64 /usr/bin/go build  -o dist/plugin-linux-amd64;
go: github.com/mattermost/mattermost-server@v5.12.0+incompatible requires
	willnorris.com/go/imageproxy@v0.8.1-0.20190326225038-d4246a08fdec: invalid pseudo-version: does not match version-control timestamp (2019-04-22T23:49:45Z)
make: *** [Makefile:88: server] Error 1
```