### PR TITLE
Log requests being sent to the skype server

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -59,10 +59,10 @@
         "help_text": "Application ID from the Azure Active Directory. Only required for Skype for Business Online. Use this URL to configure the plugin in Azure Active Directory: ```https://SITEURL/plugins/skype4business/api/v1/auth_redirect```"
       },
       {
-        "key": "LogClientRequests",
+        "key": "ShouldLogClientRequests",
         "display_name": "Enable logging requests to S4B server",
         "type": "bool",
-        "help_text": "Logging requests sent to S4B server for debugging purposes. Used only with Skype for Business Server."
+        "help_text": "Logging requests sent to S4B server for debugging purposes. Used only with Skype for Business Server. These logs will use the `INFO` log level, so make sure that `Console Log Level` is set to `INFO` in the `System Console`."
       }
     ],
     "footer": "To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/kosgrz/mattermost-plugin-skype4business)."

--- a/plugin.json
+++ b/plugin.json
@@ -62,7 +62,7 @@
         "key": "ShouldLogClientRequests",
         "display_name": "Enable logging requests to S4B server",
         "type": "bool",
-        "help_text": "Logging requests sent to S4B server for debugging purposes. Used only with Skype for Business Server. These logs will use the `INFO` log level, so make sure that `Console Log Level` is set to `INFO` in the `System Console`."
+        "help_text": "Logging requests sent to S4B server for debugging purposes. Used only with Skype for Business Server. These logs will use the `INFO` log level, so make sure that your Log Level is set to `INFO` in the `System Console`."
       }
     ],
     "footer": "To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/kosgrz/mattermost-plugin-skype4business)."

--- a/plugin.json
+++ b/plugin.json
@@ -57,6 +57,12 @@
         "display_name": "Application ID",
         "type": "text",
         "help_text": "Application ID from the Azure Active Directory. Only required for Skype for Business Online. Use this URL to configure the plugin in Azure Active Directory: ```https://SITEURL/plugins/skype4business/api/v1/auth_redirect```"
+      },
+      {
+        "key": "LogClientRequests",
+        "display_name": "Enable logging requests to S4B server",
+        "type": "bool",
+        "help_text": "Logging requests sent to S4B server for debugging purposes. Used only with Skype for Business Server."
       }
     ],
     "footer": "To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/kosgrz/mattermost-plugin-skype4business)."

--- a/server/client.go
+++ b/server/client.go
@@ -16,9 +16,9 @@ import (
 
 // Client is a new HTTP Client to talk to the Skype server
 type Client struct {
-	httpClient  *http.Client
-	logger      Logger
-	logRequests bool
+	httpClient        *http.Client
+	logger            Logger
+	shouldLogRequests bool
 }
 
 // Logger is used for logging requests
@@ -41,8 +41,8 @@ func (c *Client) setLogger(logger Logger) {
 	c.logger = logger
 }
 
-func (c *Client) setLogRequests(logRequests bool) {
-	c.logRequests = logRequests
+func (c *Client) setShouldLogRequests(shouldLogRequests bool) {
+	c.shouldLogRequests = shouldLogRequests
 }
 
 func (c *Client) authenticate(url string, body url.Values) (*AuthResponse, error) {
@@ -67,9 +67,7 @@ func (c *Client) createNewApplication(url string, body interface{}, token string
 	if err != nil {
 		return nil, err
 	}
-	if c.logRequests {
-		c.logRequest("createNewApplication", req, true)
-	}
+	c.logRequest("createNewApplication", req, true)
 	var newApplicationResponse NewApplicationResponse
 	_, err = c.do(req, &newApplicationResponse)
 	return &newApplicationResponse, err
@@ -195,7 +193,7 @@ func (c *Client) validateResponse(resp *http.Response) error {
 }
 
 func (c *Client) logRequest(methodName string, r *http.Request, hasBody bool) {
-	if c.logRequests {
+	if c.shouldLogRequests {
 		requestDump, _ := httputil.DumpRequest(r, hasBody)
 		c.logger.LogInfo("Request in "+methodName, "request", string(requestDump))
 	}

--- a/server/client.go
+++ b/server/client.go
@@ -17,13 +17,8 @@ import (
 // Client is a new HTTP Client to talk to the Skype server
 type Client struct {
 	httpClient        *http.Client
-	logger            Logger
+	logger            ILogger
 	shouldLogRequests bool
-}
-
-// Logger is used for logging requests
-type Logger interface {
-	LogInfo(msg string, keyValuePairs ...interface{})
 }
 
 // NewClient returns a new Client
@@ -37,7 +32,7 @@ func NewClient() *Client {
 	}
 }
 
-func (c *Client) setLogger(logger Logger) {
+func (c *Client) setLogger(logger ILogger) {
 	c.logger = logger
 }
 

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -44,6 +44,8 @@ type LoggerMock struct {
 
 func (l *LoggerMock) LogInfo(msg string, keyValuePairs ...interface{}) {}
 
+func (l *LoggerMock) LogWarn(msg string, keyValuePairs ...interface{}) {}
+
 func TestClient(t *testing.T) {
 	setupTestServer(t)
 	defer teardown()

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"github.com/stretchr/testify/mock"
 	"io/ioutil"
 	"math"
 	"net/http"
@@ -37,11 +38,18 @@ var (
 	server *httptest.Server
 )
 
+type LoggerMock struct {
+	mock.Mock
+}
+
+func (l *LoggerMock) LogInfo(msg string, keyValuePairs ...interface{}) {}
+
 func TestClient(t *testing.T) {
 	setupTestServer(t)
 	defer teardown()
 
 	client := NewClient()
+	client.setLogger(&LoggerMock{})
 
 	t.Run("test authenticate", func(t *testing.T) {
 

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -15,11 +15,12 @@ const (
 )
 
 type configuration struct {
-	ProductType string
-	ClientID    string
-	Username    string
-	Password    string
-	Domain      string
+	ProductType       string
+	ClientID          string
+	Username          string
+	Password          string
+	Domain            string
+	LogClientRequests bool
 }
 
 func (c *configuration) Clone() *configuration {
@@ -94,6 +95,8 @@ func (p *Plugin) OnConfigurationChange() error {
 			return errors.Wrap(err, "failed to delete saved root URL in KV Store")
 		}
 	}
+
+	p.client.setLogRequests(configuration.LogClientRequests)
 
 	p.setConfiguration(configuration)
 

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -15,12 +15,12 @@ const (
 )
 
 type configuration struct {
-	ProductType       string
-	ClientID          string
-	Username          string
-	Password          string
-	Domain            string
-	LogClientRequests bool
+	ProductType             string
+	ClientID                string
+	Username                string
+	Password                string
+	Domain                  string
+	ShouldLogClientRequests bool
 }
 
 func (c *configuration) Clone() *configuration {
@@ -96,7 +96,7 @@ func (p *Plugin) OnConfigurationChange() error {
 		}
 	}
 
-	p.client.setLogRequests(configuration.LogClientRequests)
+	p.client.setShouldLogRequests(configuration.ShouldLogClientRequests)
 
 	p.setConfiguration(configuration)
 

--- a/server/configuration_test.go
+++ b/server/configuration_test.go
@@ -54,7 +54,9 @@ func TestPlugin_OnConfigurationChange(t *testing.T) {
 			api := &plugintest.API{}
 			api.On("LoadPluginConfiguration", &configuration{}).Return(tc.returnOfLoadPluginConfiguration)
 			api.On("KVDelete", RootURLKey).Return(tc.returnOfKVDelete)
-			p := Plugin{}
+			p := Plugin{
+				client: NewClient(),
+			}
 			p.setConfiguration(&configuration{Domain: tc.initialDomain})
 			p.SetAPI(api)
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -50,7 +50,7 @@ type IClient interface {
 	performRequestAndGetAuthHeader(url string) (*string, error)
 	readUserResource(url string, token string) (*UserResourceResponse, error)
 	setLogger(logger Logger)
-	setLogRequests(logRequests bool)
+	setShouldLogRequests(shouldLogRequests bool)
 }
 
 // Plugin represents the plugin api.
@@ -76,7 +76,7 @@ func (p *Plugin) OnActivate() error {
 	}
 
 	p.client.setLogger(p.API)
-	p.client.setLogRequests(config.LogClientRequests)
+	p.client.setShouldLogRequests(config.ShouldLogClientRequests)
 
 	return nil
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -49,6 +49,8 @@ type IClient interface {
 	performDiscovery(url string) (*DiscoveryResponse, error)
 	performRequestAndGetAuthHeader(url string) (*string, error)
 	readUserResource(url string, token string) (*UserResourceResponse, error)
+	setLogger(logger Logger)
+	setLogRequests(logRequests bool)
 }
 
 // Plugin represents the plugin api.
@@ -72,6 +74,9 @@ func (p *Plugin) OnActivate() error {
 	if err := config.IsValid(); err != nil {
 		return err
 	}
+
+	p.client.setLogger(p.API)
+	p.client.setLogRequests(config.LogClientRequests)
 
 	return nil
 }

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -136,6 +136,7 @@ func TestPlugin(t *testing.T) {
 
 			p := Plugin{
 				client: &ClientMock{},
+				logger: &LoggerMock{},
 			}
 			p.setConfiguration(&configuration{
 				ClientID:    "123123123",
@@ -276,7 +277,10 @@ func makeMocks(mmChannelID string, mmUser model.User, splitDomain bool) Mocks {
 		tokenToBeUsed,
 	).Return(&newMeetingResponseToReturn, nil).Times(1)
 
-	p := Plugin{client: &clientMock}
+	p := Plugin{
+		client: &clientMock,
+		logger: &LoggerMock{},
+	}
 	p.SetAPI(&api)
 	p.setConfiguration(&pluginConfigToReturn)
 
@@ -431,7 +435,7 @@ type ClientMock struct {
 	mock.Mock
 }
 
-func (c *ClientMock) setLogger(logger Logger) {}
+func (c *ClientMock) setLogger(logger ILogger) {}
 
 func (c *ClientMock) setShouldLogRequests(shouldLogRequests bool) {}
 

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -433,7 +433,7 @@ type ClientMock struct {
 
 func (c *ClientMock) setLogger(logger Logger) {}
 
-func (c *ClientMock) setLogRequests(logRequests bool) {}
+func (c *ClientMock) setShouldLogRequests(shouldLogRequests bool) {}
 
 func (c *ClientMock) authenticate(url string, body url.Values) (*AuthResponse, error) {
 	ret := c.Called(url, body)

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -134,7 +134,9 @@ func TestPlugin(t *testing.T) {
 			api.On("PublishWebSocketEvent", "authenticated", mock.Anything, mock.Anything).Return()
 			api.On("LogWarn", mock.AnythingOfTypeArgument("string"), mock.AnythingOfTypeArgument("string")).Return()
 
-			p := Plugin{}
+			p := Plugin{
+				client: &ClientMock{},
+			}
 			p.setConfiguration(&configuration{
 				ClientID:    "123123123",
 				ProductType: productTypeOnline,
@@ -428,6 +430,10 @@ func makePost(mmUser model.User, channelID string, createdMeeting NewMeetingResp
 type ClientMock struct {
 	mock.Mock
 }
+
+func (c *ClientMock) setLogger(logger Logger) {}
+
+func (c *ClientMock) setLogRequests(logRequests bool) {}
 
 func (c *ClientMock) authenticate(url string, body url.Values) (*AuthResponse, error) {
 	ret := c.Called(url, body)


### PR DESCRIPTION
#### Summary
This PR adds possibilty to log requests being sent to S4B server.

Example request log looks like that:
```
INFO[2020-08-31T01:54:39.1703646+02:00] Request in createNewApplication caller="mlog/sugar.go:19" plugin_id=skype4business request="POST /ucwa/oauth/v1/applications HTTP/1.1\r\nHost: testdomain.com\r\nAccept: application/json\r\nAuthorization: Bearer simpletoken123simpletoken123simpletoken123simpletoken123simpletoken123simpletoken123simpletoken123simpletoken123\r\nContent-Type: application/json\r\n\r\n{\"UserAgent\":\"mm_skype4b_plugin\",\"EndpointId\":\"123\",\"Culture\":\"en-US\"}\n"
```

Fixes https://github.com/mattermost/mattermost-plugin-skype4business/issues/58