### PR TITLE
fix URL to the plugin repository in the plugin.json

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -59,6 +59,6 @@
         "help_text": "Application ID from the Azure Active Directory. Only required for Skype for Business Online. Use this URL to configure the plugin in Azure Active Directory: ```https://SITEURL/plugins/skype4business/api/v1/auth_redirect```"
       }
     ],
-    "footer": "To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/kosgrz/mattermost-plugin-skype4business)."
+    "footer": "To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/mattermost/mattermost-plugin-skype4business)."
   }
 }


### PR DESCRIPTION
#### Summary
I've just spotted that the plugin repository points to my old repository `https://github.com/kosgrz/mattermost-plugin-skype4business` instead of `https://github.com/mattermost/mattermost-plugin-skype4business` in the plugin.json :D
