### PR TITLE
Fix linter errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,60 +3,46 @@ run:
   modules-download-mode: readonly
 
 linters-settings:
-  goconst:
-    min-len: 2
-    min-occurrences: 2
   gofmt:
     simplify: true
   goimports:
     local-prefixes: github.com/mattermost/mattermost-plugin-skype4business
-  golint:
-    min-confidence: 0
   govet:
     check-shadowing: true
     enable-all: true
+    disable:
+      - fieldalignment
   misspell:
     locale: US
 
 linters:
   disable-all: true
   enable:
-    # - bodyclose
-    - deadcode
-    # - errcheck
-    - goconst
+    - bodyclose
+    - errcheck
     - gocritic
     - gofmt
     - goimports
-    - golint
-    # - gosec
+    - gosec
     - gosimple
     - govet
     - ineffassign
-    # - interfacer
     - misspell
     - nakedret
+    - revive
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - whitespace
 
 issues:
   exclude-rules:
-    - path: server/manifest.go
-      linters:
-        - deadcode
-        - unused
-        - varcheck
     - path: server/configuration.go
       linters:
         - unused
     - path: _test\.go
       linters:
         - bodyclose
-        - goconst
         - scopelint # https://github.com/kyoh86/scopelint/issues/4

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -178,7 +178,7 @@ func TestClient(t *testing.T) {
 		resp = &http.Response{
 			Status:     strconv.Itoa(http.StatusInternalServerError) + " " + http.StatusText(http.StatusInternalServerError),
 			StatusCode: http.StatusInternalServerError,
-			Body:       ioutil.NopCloser(bytes.NewBufferString("test body")),
+			Body:       io.NopCloser(bytes.NewBufferString("test body")),
 		}
 
 		err = client.validateResponse(resp)
@@ -192,7 +192,7 @@ func TestClient(t *testing.T) {
 		resp = &http.Response{
 			Status:     strconv.Itoa(http.StatusInternalServerError) + " " + http.StatusText(http.StatusInternalServerError),
 			StatusCode: http.StatusInternalServerError,
-			Body:       ioutil.NopCloser(bytes.NewBufferString("")),
+			Body:       io.NopCloser(bytes.NewBufferString("")),
 		}
 
 		err = client.validateResponse(resp)


### PR DESCRIPTION
#### Summary
Fix linter errors caused by `golangci-lint` update.

#### Ticket Link
None