### PR TITLE
Fix webapp base url calculation

### DIFF
--- a/webapp/src/selectors/index.js
+++ b/webapp/src/selectors/index.js
@@ -10,7 +10,10 @@ export const getPluginServerRoute = (state) => {
     let basePath = '';
     if (config?.SiteURL) {
         basePath = new URL(config.SiteURL).pathname;
-        basePath.replace(/\/$/, '');
+
+        if (basePath && basePath[basePath.length - 1] === '/') {
+            basePath = basePath.substring(0, basePath.length - 1);
+        }
     }
 
     return basePath;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

There's a typo in the webapp portion of the plugin with calculating the base url of the server. This PR resolves the issue by matching the logic used in other plugins.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

